### PR TITLE
Add Student model to `large_models` array

### DIFF
--- a/admin/model_admins/base.py
+++ b/admin/model_admins/base.py
@@ -9,6 +9,7 @@ from base_auth.models import User
 
 Person = swapper.load_model('kernel', 'Person')
 Student = swapper.load_model('kernel', 'Student')
+FacultyMember = swapper.load_model('kernel', 'FacultyMember')
 
 class ModelAdmin(admin.ModelAdmin):
     """
@@ -24,6 +25,7 @@ class ModelAdmin(admin.ModelAdmin):
         Person,
         User,
         Student,
+        FacultyMember,
     ]
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/admin/model_admins/base.py
+++ b/admin/model_admins/base.py
@@ -8,7 +8,7 @@ from django.contrib.admin.widgets import (
 from base_auth.models import User
 
 Person = swapper.load_model('kernel', 'Person')
-
+Student = swapper.load_model('kernel', 'Student')
 
 class ModelAdmin(admin.ModelAdmin):
     """
@@ -23,6 +23,7 @@ class ModelAdmin(admin.ModelAdmin):
     large_models = [
         Person,
         User,
+        Student,
     ]
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):


### PR DESCRIPTION
Admin add/edit view of models of having foreign key to `Student` fails to open student count when goes near 7-8k. Adding `Student` to `large_models` array to have similar fix as that of `User` and `Person` model.