### PR TITLE
Add a property to calculate duration

### DIFF
--- a/mixins/period_mixin.py
+++ b/mixins/period_mixin.py
@@ -147,55 +147,12 @@ class PeriodMixin(Model):
         else:
             difference = relativedelta(self.end_date, self.start_date)
 
-        period_duration = ''
-        years = __class__.get_date_attribute(difference.years, 'year')
-        if years:
-            period_duration += f'{years} '
-
-        months = __class__.get_date_attribute(difference.months, 'month')
-        if months:
-            period_duration += f'{months} '
-
-        days = __class__.get_date_attribute(difference.days, 'day')
-        period_duration += f'{days}'
-
-        period_duration = period_duration.rstrip()
+        period_duration = {
+            'years': difference.years,
+            'months': difference.months,
+            'days': difference.days,
+        }
         return period_duration
-
-    @staticmethod
-    def get_date_attribute(period, singular_suffix, plural_suffix=None):
-        """
-        Return the period with its suffix
-
-        :param period: the duration of the attribute
-        :param singular_suffix: the type of the attribute of date
-        :param plural_suffix: the plural form of the attribute, defaults to
-        None (append 's' to `singular_suffix`)
-        :return: Return the period with its suffix
-        """
-
-        suffix = singular_suffix
-        if period > 0:
-            if __class__.is_plural(period):
-                if plural_suffix is None:
-                    suffix = f'{suffix}s'
-                else:
-                    suffix = plural_suffix
-            return f'{period} {suffix}'
-        return ''
-
-    @staticmethod
-    def is_plural(number):
-        """
-        Check if the number is plural
-
-        :param number: the number which has to be checked
-        :return: whether the number is plural
-        """
-
-        if number > 1:
-            return True
-        return False
 
 class BlurryPeriodMixin(PeriodMixin):
     """
@@ -210,31 +167,14 @@ class BlurryPeriodMixin(PeriodMixin):
     @property
     def duration(self):
         """
-        Return duration of the period
-        :return duration of the period:
+        Return duration of the period after omitting days
+        :return: duration of the period after omitting days
         """
 
-        if self.is_full_date:
-            return super(BlurryPeriodMixin, self).duration
-
-        difference = None
-        if self.end_date is None:
-            today = datetime.date.today()
-            difference = relativedelta(today, self.start_date)
-        else:
-            difference = relativedelta(self.end_date, self.start_date)
-
-        period_duration = ''
-        years = __class__.get_date_attribute(difference.years, 'year')
-        if years:
-            period_duration += f'{years} '
-
-        months = __class__.get_date_attribute(difference.months, 'month')
-        period_duration += f'{months}'
-
-        period_duration = period_duration.rstrip()
+        period_duration = super(__class__, self).duration
+        if not self.is_full_date:
+            del period_duration['days']
         return period_duration
-
 
     class Meta:
         """

--- a/mixins/period_mixin.py
+++ b/mixins/period_mixin.py
@@ -140,12 +140,8 @@ class PeriodMixin(Model):
         :return: the duration of the period
         """
 
-        difference = None
-        if self.end_date is None:
-            today = datetime.date.today()
-            difference = relativedelta(today, self.start_date)
-        else:
-            difference = relativedelta(self.end_date, self.start_date)
+        end_date = self.end_date or datetime.date.today()
+        difference = relativedelta(end_date, self.start_date)
 
         period_duration = {
             'years': difference.years,

--- a/mixins/period_mixin.py
+++ b/mixins/period_mixin.py
@@ -167,7 +167,7 @@ class BlurryPeriodMixin(PeriodMixin):
         :return: duration of the period after omitting days
         """
 
-        period_duration = super(__class__, self).duration
+        period_duration = super().duration
         if not self.is_full_date:
             del period_duration['days']
         return period_duration

--- a/mixins/period_mixin.py
+++ b/mixins/period_mixin.py
@@ -207,6 +207,35 @@ class BlurryPeriodMixin(PeriodMixin):
         default=False,
     )
 
+    @property
+    def duration(self):
+        """
+        Return duration of the period
+        :return duration of the period:
+        """
+
+        if self.is_full_date:
+            return super(BlurryPeriodMixin, self).duration
+
+        difference = None
+        if self.end_date is None:
+            today = datetime.date.today()
+            difference = relativedelta(today, self.start_date)
+        else:
+            difference = relativedelta(self.end_date, self.start_date)
+
+        period_duration = ''
+        years = __class__.get_date_attribute(difference.years, 'year')
+        if years:
+            period_duration += f'{years} '
+
+        months = __class__.get_date_attribute(difference.months, 'month')
+        period_duration += f'{months}'
+
+        period_duration = period_duration.rstrip()
+        return period_duration
+
+
     class Meta:
         """
         Meta class for BlurryPeriodMixin


### PR DESCRIPTION
These calculate the duration of an instance. Eg. `1 year 3 months 2 days`

As one can see from the code, I have violated DRY in the [second commit](https://github.com/IMGIITRoorkee/omniport-backend-formula-one/commit/49c4ba4e867d6e523cc80a96f2f5a1517b072282). I would prefer if anyone suggests me a better way to do this. 