### PR TITLE
Handle `ValueError` when end_date is populated via admin panel

### DIFF
--- a/mixins/period_mixin.py
+++ b/mixins/period_mixin.py
@@ -37,7 +37,7 @@ class PeriodMixin(Model):
 
         if (self.end_date is not None) and (self.end_date < self.start_date):
             raise ValidationError({
-                'Invalid period': 'End date cannot be before start date.'
+                'end_date': 'End date cannot be before start date.'
             })
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Django assumes the key of the `error_dict` is a field name. Since "Invalid period" isn't a field, a `Value Error` was being raised.